### PR TITLE
Parameterize Parser by AST output type

### DIFF
--- a/examples/token_spec.rs
+++ b/examples/token_spec.rs
@@ -32,13 +32,13 @@ impl Display for CToken {
 fn token_spec() -> Result<ParserSpec<CToken>, SpecificationError<CToken>> {
     let mut spec = ParserSpec::new();
     add_null_assoc!(spec, PrecedenceLevel::Root, (CToken::Number("".to_string()), CToken::Ident("".to_string())) => |_, token: CToken, _| {
-        Ok(Node::Simple(token.clone()))
+        Ok(SimpleNode::Plain(token.clone()))
     });
     add_left_assoc!(spec, PrecedenceLevel::First, (CToken::Add, CToken::Sub) => |parser, token, lbp, node| {
-        Ok(Node::Composite { token: token.clone(), children: vec![node, parser.parse_expr(lbp)?] } )
+        Ok(SimpleNode::Composite { token: token.clone(), children: vec![node, parser.parse_expr(lbp)?] } )
     } );
     add_left_assoc!(spec, PrecedenceLevel::Second, (CToken::Mul, CToken::Div, CToken::Mod) => |parser, token, lbp, node| {
-        Ok(Node::Composite { token: token.clone(), children: vec![node, parser.parse_expr(lbp)?] } )
+        Ok(SimpleNode::Composite { token: token.clone(), children: vec![node, parser.parse_expr(lbp)?] } )
     } );
     add_null_assoc!(spec, PrecedenceLevel::First, (CToken::LParens) => |parser, _, lbp| {
         let res = parser.parse_expr(lbp)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,7 +30,7 @@
 
 use std::marker::{Send, Sync};
 
-use node::Node;
+use node::SimpleNode;
 use token::Token;
 
 /// # ParseError
@@ -54,7 +54,7 @@ pub enum ParseError<T: Token + Send + Sync + 'static> {
     /// the syntax rule, and *token* for the token that lead to
     /// the error to be returned.
     #[fail(display = "incorrect syntax, failed on node: {} with token: {}", node, token)]
-    MalformedSyntax{ node: Node<T>, token: T }, 
+    MalformedSyntax{ node: SimpleNode<T>, token: T }, 
     /// Returned by the parser when a rule is not found for a specific token.
     /// Generally only should be seen during development of a language spec.
     #[fail(display = "missing a {} syntax rule for: {}", ty, token)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,7 +20,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-//! # Node enum
+//! # SimpleNode enum
 //! 
 //! This is a general purpose enum construct for representing parse trees. 
 //! 
@@ -39,21 +39,21 @@ use std::fmt::{Display, Error, Formatter};
 use token::Token;
 
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum Node<T: Token> {
-    Simple(T), 
+pub enum SimpleNode<T: Token> {
+    Plain(T), 
     Composite {
         token: T,
-        children: Vec<Node<T>>
+        children: Vec<SimpleNode<T>>
     }
 }
 
-impl<T: Token> Display for Node<T> {
+impl<T: Token> Display for SimpleNode<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error>{
         write!(f,
             "{}", 
             match self {
-                Node::Simple(ref t) => format!("Simple({})", t), 
-                Node::Composite{
+                SimpleNode::Plain(ref t) => format!("Plain({})", t), 
+                SimpleNode::Composite{
                     token: ref t, 
                     children: ref childs
                 } => format!("Composite(token: {}, children: {:?})", t, childs )
@@ -69,12 +69,12 @@ mod test {
     #[test]
     fn test_node_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<Node<String>>();
+        assert_send::<SimpleNode<String>>();
     }
 
     #[test]
     fn test_node_sync() {
         fn assert_sync<T: Sync>() {}
-        assert_sync::<Node<String>>();
+        assert_sync::<SimpleNode<String>>();
     }
 }

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -44,20 +44,39 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum PrecedenceLevel {
-    Root    = 0, 
-    First   = 5, 
-    Second  = 10, 
-    Third   = 15, 
-    Fourth  = 20, 
-    Fifth   = 25, 
-    Sixth   = 30, 
-    Seventh = 35, 
-    Eighth  = 40,
+pub struct PrecedenceLevel(u32);
+
+macro_rules! levels {
+    ( $($name:ident = $val:literal),+ ) => {
+        $(
+            #[allow(non_upper_case_globals)]
+            pub const $name: PrecedenceLevel = PrecedenceLevel($val);
+        )+
+    }
+}
+
+impl PrecedenceLevel {
+    levels! (
+        Root = 0,
+        First = 5,
+        Second = 10,
+        Third = 15,
+        Fourth = 20,
+        Fifth = 25,
+        Sixth = 30,
+        Seventh = 35,
+        Eighth = 40
+    );
+
+    /// Arbitrary precedence higher than 40.
+    pub fn higher(x: u32) -> Self {
+        debug_assert!(x > 40, "User-provided precedence should be higher than 40 but was {}", x);
+        Self(x)
+    }
 }
 
 impl Display for PrecedenceLevel {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        write!(f, "(Precedence: {})", *self as u32)
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "(Precedence: {})", self.0)
     }
 }


### PR DESCRIPTION
I renamed `Node` to `SimpleNode` since I would like to be able to use `Node` as a type variable name throughout the codebase.

This diff also adds the ability to use arbitrary higher precedence levels (the language I'm trying to parse requires 11).